### PR TITLE
Fix triple tree traversal on checkbox click

### DIFF
--- a/Assets/com.anchorpoint.sourcecontrol/Editor/Anchorpoint/Scripts/Editor/AnchorpointEditor.cs
+++ b/Assets/com.anchorpoint.sourcecontrol/Editor/Anchorpoint/Scripts/Editor/AnchorpointEditor.cs
@@ -196,10 +196,10 @@ namespace Anchorpoint.Editor
                         SetAllCheckboxesRecursive(itemData.Children, evt.newValue);
                     }
 
-                    commitButton.SetEnabled(IsAnyFileSelected()); // Update the commit button state
-                    revertButton.SetEnabled(IsAnyFileSelected()); // Update the revert button state
-                    commitMessageField.SetEnabled(IsAnyFileSelected());
-
+                    var isAnyFileSelected = IsAnyFileSelected();
+                    commitButton.SetEnabled(isAnyFileSelected); // Update the commit button state
+                    revertButton.SetEnabled(isAnyFileSelected); // Update the revert button state
+                    commitMessageField.SetEnabled(isAnyFileSelected);
                     // Refresh all visible items in the tree view
                     treeView.RefreshItems();
                 });


### PR DESCRIPTION
When I have 1k new files, clicking any box in the tree requires ~20 seconds. With this fix it's only 5 seconds